### PR TITLE
Implemented `@On` Restrictions

### DIFF
--- a/examples/simple/AppDiscord.ts
+++ b/examples/simple/AppDiscord.ts
@@ -5,7 +5,7 @@ import {
 } from "../../src";
 // You must import the types from @types/discord.js
 import {
-  Message
+  Message, MessageEmbed
 } from "discord.js";
 
 // Decorate the class with the @Discord decorator
@@ -14,7 +14,8 @@ export class AppDiscord {
   private static _client: Client;
   private _prefix: string = "!";
   private _sayHelloMessage: string = "hello !";
-  private _commandNotFoundMessage: string = "command not found...";
+  private _restrictionMessage: string = "You can make seperate functions for each command thanks to restrictions!";
+  private _hashtagMessage: string = "Restrictions work!";
 
   static start() {
     this._client = new Client();
@@ -33,16 +34,22 @@ export class AppDiscord {
     if (AppDiscord._client.user.id !== message.author.id) {
       if (message.content[0] === this._prefix) {
         const cmd = message.content.replace(this._prefix, "").toLowerCase();
-        switch (cmd) {
-          case "hello":
-            message.reply(this._sayHelloMessage);
-            break;
-          default:
-            message.reply(this._commandNotFoundMessage);
-            break;
+        if (cmd === "hello") {
+          message.reply(this._sayHelloMessage);
         }
       }
     }
+  }
+
+  // When the "message" event is triggered, and it passes your restriction, this method gets called.
+  @On("message", [String.prototype.startsWith, "!restriction"])
+  async onRestrictionCommand(message: Message, client: Client) {
+    message.reply(this._restrictionMessage);
+  }
+
+  @On("message", [String.prototype.endsWith, "#works"])
+  async onWorksHashtag(message: Message, client: Client) {
+    message.channel.send(this._hashtagMessage);
   }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "@discord.ts/bot",
-  "version": "1.0.0",
+  "name": "@typeit/discord",
+  "version": "1.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -21,7 +21,7 @@ export class Client extends ClientJS {
     this.loadClasses();
 
     MetadataStorage.Instance.Build();
-    MetadataStorage.Instance.Ons.map((on) => {
+    MetadataStorage.Instance.Ons.forEach((on) => {
       const fn = (...params: any[]) => {
         if (on.params.linkedInstance && on.params.linkedInstance.instance) {
           on.params.method.bind(on.params.linkedInstance.instance)(...params, this);
@@ -43,15 +43,13 @@ export class Client extends ClientJS {
   }
 
   private loadClasses() {
-    if (this._loadClasses) {
-      this._loadClasses.map((file) => {
-        if (typeof file === "string") {
-          const files = Glob.sync(file);
-          files.map((file) => {
-            require(file);
-          });
-        }
-      });
-    }
+    if (this._loadClasses) this._loadClasses.forEach((file) => {
+      if (typeof file === "string") {
+        const files = Glob.sync(file);
+        files.forEach((file) => {
+          require(file);
+        });
+      }
+    });
   }
 }

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -21,23 +21,7 @@ export class Client extends ClientJS {
     this.loadClasses();
 
     MetadataStorage.Instance.Build();
-    MetadataStorage.Instance.Ons.forEach((on) => {
-      const fn = (...params: any[]) => {
-        if (on.params.linkedInstance && on.params.linkedInstance.instance) {
-          on.params.method.bind(on.params.linkedInstance.instance)(...params, this);
-        } else {
-          on.params.method(...params, this);
-        }
-      };
-      if (on.params.once) {
-        this.once(on.params.event, fn);
-      } else {
-        this.on(on.params.event, fn);
-      }
-      if (!this.silent) {
-        console.log(`${on.params.event}: ${on.class.name}.${on.key}`);
-      }
-    });
+    MetadataStorage.Instance.Map(this);
 
     return super.login(token);
   }

--- a/src/Decorators/On.ts
+++ b/src/Decorators/On.ts
@@ -3,18 +3,35 @@ import {
   DiscordEvent
 } from "..";
 
-export function On(event: DiscordEvent);
-export function On(event: string);
-export function On(event: DiscordEvent | string) {
-  return (target: Object, key: string, descriptor: PropertyDescriptor): void => {
-    MetadataStorage.Instance.AddOn({
-      class: target.constructor,
-      key,
-      params: {
-        event,
-        once: false,
-        method: descriptor.value
-      }
-    });
-  };
+export function On(event: DiscordEvent, restriction?: [Function , string]);
+export function On(event: string, restriction?: [Function , string]);
+export function On(event: DiscordEvent | string, restriction?: [Function , string]) {
+  if(event === "message" && restriction){
+    return (target: Object, key: string, descriptor: PropertyDescriptor): void => {
+      MetadataStorage.Instance.AddOn({
+        class: target.constructor,
+        key,
+        params: {
+          event,
+          once: false,
+          method: descriptor.value,
+          restriction: restriction
+        }
+      });
+    };
+  }else if(restriction){ // Only message events can be restricted
+    throw '@On may only be restricted with "message" event';
+  }else{
+    return (target: Object, key: string, descriptor: PropertyDescriptor): void => {
+      MetadataStorage.Instance.AddOn({
+        class: target.constructor,
+        key,
+        params: {
+          event,
+          once: false,
+          method: descriptor.value
+        }
+      });
+    };
+  }
 }

--- a/src/Logic/MetadataStorage.ts
+++ b/src/Logic/MetadataStorage.ts
@@ -34,11 +34,9 @@ export class MetadataStorage {
   }
 
   Build() {
-    this._ons.map((on) => {
+    this._ons.forEach((on) => {
       const instance = this._instances.find((instance) => instance.class === on.class);
-      if (instance) {
-        on.params.linkedInstance = instance.params;
-      }
+      if (instance) on.params.linkedInstance = instance.params;
     });
   }
 

--- a/src/Logic/MetadataStorage.ts
+++ b/src/Logic/MetadataStorage.ts
@@ -4,6 +4,7 @@ import {
   IInstance,
   Client
 } from "..";
+import { Message } from 'discord.js';
 
 export class MetadataStorage {
   private static _instance: MetadataStorage;
@@ -38,12 +39,24 @@ export class MetadataStorage {
   }
 
   Map(client: Client) {
+    console.log('Mapping functions...');
     this._ons.forEach((on) => {
       const fn = (...params: any[]) => {
-        if (on.params.linkedInstance && on.params.linkedInstance.instance) {
-          on.params.method.bind(on.params.linkedInstance.instance)(...params, this);
-        } else {
-          on.params.method(...params, this);
+        if (on.params.restriction) { // @On has a set restriction
+          let restrictor: Function = on.params.restriction[0];
+          if (restrictor.bind(params[0].content)(on.params.restriction[1])) {
+            if (on.params.linkedInstance && on.params.linkedInstance.instance) {
+              on.params.method.bind(on.params.linkedInstance.instance)(...params, this);
+            } else {
+              on.params.method(...params, this);
+            }
+          }
+        } else { // @On has no set restriction
+          if (on.params.linkedInstance && on.params.linkedInstance.instance) {
+            on.params.method.bind(on.params.linkedInstance.instance)(...params, this);
+          } else {
+            on.params.method(...params, this);
+          }
         }
       };
       if (on.params.once) {

--- a/src/Types/IOn.ts
+++ b/src/Types/IOn.ts
@@ -7,5 +7,6 @@ export interface IOn {
   event: DiscordEvent | string;
   method: (...params: any[]) => void;
   linkedInstance?: IInstance;
+  restriction?: [Function, string],
   once: boolean;
 }


### PR DESCRIPTION
I have implemented the possibility to further specify the `@On()` decorator with a restrictor.
In addition to the event it takes a function like `String.prototype.startsWith` and an appropriate argument.
When a new message gets sent it gets compared to the given argument with the specified function.
Example:
```Typescript
@On("message")
async onMessage(message: Message, client: Client){
    if(message.content.startsWith("!command")){
        // Do something with the command
    }
}
// The above function can now alternatively be written like this
@On("message", [String.prototype.startsWith,"!command"])
async onMessage(message: Message, client: Client){
    // Do something with the command
}
``` 

With only one command this is not really necessary but as soon as there are multiple commands, having seperate functions instead of one with a lot of if's and else's is greatly improving readability of the code.

Currently this is only supported with `"message"` events as it requires a text content which can be compared.