### PR TITLE
Fix command case sensitivity

### DIFF
--- a/src/Logic/MetadataStorage.ts
+++ b/src/Logic/MetadataStorage.ts
@@ -101,18 +101,20 @@ export class MetadataStorage {
                 message.params = params;
                 message.params.splice(0, 1);
 
+                let commandName = on.params.commandName;
                 if (
                   !on.params.linkedInstance.params.commandCaseSensitive &&
                   !on.params.commandCaseSensitive
                 ) {
                   testedCommand = testedCommand.toLowerCase();
+                  commandName = commandName.toLowerCase();
                 }
 
                 if (commands.indexOf(originalCommand) === -1) {
                   testedCommand = "";
                 }
 
-                if (testedCommand === on.params.commandName) {
+                if (testedCommand === commandName) {
                   execute = true;
                   command = on;
                 }


### PR DESCRIPTION
When printing a command list, you may want the command name to be in mixed case, but still not care about case when matching.
Previously all commands implicitly had to be in lower case when commandCaseSensitive was false, or nothing would match.

I threw this together quickly in the github online editor, so I haven't tested it. But it should work. :)