### PR TITLE
fix(case sensitivity), again

### DIFF
--- a/src/Logic/MetadataStorage.ts
+++ b/src/Logic/MetadataStorage.ts
@@ -102,15 +102,17 @@ export class MetadataStorage {
                 message.params = params;
                 message.params.splice(0, 1);
 
+                let allCommands = commands;
                 if (
                   !on.params.linkedInstance.params.commandCaseSensitive &&
                   !on.params.commandCaseSensitive
                 ) {
                   testedCommand = testedCommand.toLowerCase();
                   commandName = commandName.toLowerCase();
+                  allCommands = allCommands.map(String.prototype.toLowerCase);
                 }
 
-                if (commands.indexOf(originalCommand) === -1) {
+                if (allCommands.indexOf(testedCommand) === -1) {
                   testedCommand = "";
                 }
 


### PR DESCRIPTION
Bumped to the new version and realised my fix did not in fact work!

I tried to test this one out locally, but couldn't figure out how to link your package locally. There are no scripts in package.json, and a simple `tsc` did not include the package.json in the output, so node would not identify it as a module.