### PR TITLE
fix tiny import error on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,8 @@ import {
   On,
   Client,
   Command,
-  CommandMessage
+  CommandMessage,
+  CommandNotFound
 } from "@typeit/discord";
 
 @Discord("!") // Specify your prefix


### PR DESCRIPTION
add import "CommandNotFound" on example of usage of the Commands