### PR TITLE
Fixed 'classType is not a constructor' error when passing classes to …

### DIFF
--- a/src/decorators/decorators/Discord.ts
+++ b/src/decorators/decorators/Discord.ts
@@ -96,7 +96,7 @@ export function Discord(prefix?: Expression | ExpressionFunction, params?: Disco
             importCommand(classType, target);
           });
         } else {
-          importCommand((cmd as any).execute, target);
+          importCommand(cmd, target);
         }
       });
     }


### PR DESCRIPTION
…`@Discord` import option. It seems that the code removed is not needed for this to work, unless I am not aware of a use case where this is required.
