### PR TITLE
The same Infos and commandName properties in commandMessage bug fix;

### DIFF
--- a/src/logic/metadatas/MetadataStorage.ts
+++ b/src/logic/metadatas/MetadataStorage.ts
@@ -129,7 +129,8 @@ export class MetadataStorage {
     });
 
     return async (...params: ArgsOf<Event>) => {
-      let paramsToInject: any = params;
+      let paramsToInject: ArgsOf<Event> | CommandMessage = params;
+      const message = params[0] as Message;
       const isMessage = event === "message";
       let isCommand = false;
       let notFoundOn;
@@ -137,7 +138,6 @@ export class MetadataStorage {
 
       onCommands = (await Promise.all(this.events.map(async (on) => {
         if (isMessage && on instanceof DCommand) {
-          const message = params[0] as Message;
           isCommand = true;
           let pass: RuleBuilder[] = undefined;
 
@@ -195,7 +195,6 @@ export class MetadataStorage {
               commandMessage.commandContent = commandMessage.commandContent.replace(cdr.regex, "");
             });
 
-            paramsToInject = commandMessage;
             return on;
           } else {
             // If it doesn't pass any of the rules => execute the commandNotFound only on the discord instance that match the message discord rules
@@ -237,6 +236,13 @@ export class MetadataStorage {
       }
 
       for (const on of eventsToExecute) {
+        if (on instanceof DCommand) {
+          paramsToInject = CommandMessage.create(
+             message,
+             on
+          );
+        }
+
         let injectedParams = paramsToInject;
         if (
           isCommand &&

--- a/src/logic/metadatas/MetadataStorage.ts
+++ b/src/logic/metadatas/MetadataStorage.ts
@@ -129,7 +129,7 @@ export class MetadataStorage {
     });
 
     return async (...params: ArgsOf<Event>) => {
-      let paramsToInject: ArgsOf<Event> | CommandMessage = params;
+      let paramsToInject: any = params;
       const message = params[0] as Message;
       const isMessage = event === "message";
       let isCommand = false;

--- a/src/logic/metadatas/MetadataStorage.ts
+++ b/src/logic/metadatas/MetadataStorage.ts
@@ -135,6 +135,7 @@ export class MetadataStorage {
       let isCommand = false;
       let notFoundOn;
       let onCommands = [];
+      const commandParamsToExecute: Map<string, CommandMessage> = new Map<string, CommandMessage>();
 
       onCommands = (await Promise.all(this.events.map(async (on) => {
         if (isMessage && on instanceof DCommand) {
@@ -195,6 +196,8 @@ export class MetadataStorage {
               commandMessage.commandContent = commandMessage.commandContent.replace(cdr.regex, "");
             });
 
+            commandParamsToExecute.set(commandMessage.commandName.toString(), commandMessage);
+
             return on;
           } else {
             // If it doesn't pass any of the rules => execute the commandNotFound only on the discord instance that match the message discord rules
@@ -237,10 +240,7 @@ export class MetadataStorage {
 
       for (const on of eventsToExecute) {
         if (on instanceof DCommand) {
-          paramsToInject = CommandMessage.create(
-             message,
-             on
-          );
+          paramsToInject = commandParamsToExecute.get(on.commandName.toString());
         }
 
         let injectedParams = paramsToInject;

--- a/src/logic/utils/RuleBuilder.ts
+++ b/src/logic/utils/RuleBuilder.ts
@@ -48,6 +48,10 @@ export class RuleBuilder {
     }
   }
 
+  toString() {
+    return this.regex.toString();
+  }
+
   static validate(text: string, rules: ArgsRulesFunction[]) {
     console.log(text, rules);
     return true;


### PR DESCRIPTION
```
abstract class CommandA {
  @Command("commandA")
  @Infos({
    testProp: "test info 1"
  })
  async run(command: CommandMessage) {
    console.log(command.infos);
  }
}
...
abstract class CommandB {
  @Command("commandB")
  @Infos({
    testProp: "test info 2"
  })
  async run(command: CommandMessage) {
    console.log(command.infos);
  }
}
```
From example above in console will be printed the same object twice with "test info 1" or "test info 2" what depends on an order of processing in code part started from [this line](https://github.com/OwenCalvin/discord.ts/blob/cc707edd2086c6ce14c004e4c58ceafc12978353/src/logic/metadatas/MetadataStorage.ts#L153).
commandName property that in `command` argument passed in `run` function also has a wrong value by the same reasons.