### PR TITLE
fix: ensure number safety when parsing args

### DIFF
--- a/src/types/public/CommandMessage.ts
+++ b/src/types/public/CommandMessage.ts
@@ -55,7 +55,7 @@ export class CommandMessage<
       const value = argsValues[index];
       const numberValue = Number(value);
 
-      message.args[normalized] = Number.isNaN(numberValue) ? value : numberValue;
+      message.args[normalized] = Number.isNaN(numberValue) || !Number.isSafeInteger(numberValue) ? value : numberValue;
     });
   }
 }


### PR DESCRIPTION
Modified from the snippet at #18 .
Until this is merged, we cannot give snowflakes as arguments for commands (like user or channel IDs).