### PR TITLE
Fixed issue: Class with commands no longer needs to be the first export

### DIFF
--- a/src/decorators/decorators/Discord.ts
+++ b/src/decorators/decorators/Discord.ts
@@ -24,42 +24,42 @@ function importCommand(classType: Function, target: Function) {
     if (event instanceof DCommand) {
       const newCommand = (
         DCommand
-        .createCommand(
-          event.commandName
-        )
-        .decorate(
-          target,
-          event.key,
-          event.method,
-          classType
-        )
+          .createCommand(
+            event.commandName
+          )
+          .decorate(
+            target,
+            event.key,
+            event.method,
+            classType
+          )
       );
       MetadataStorage.instance.addCommand(newCommand);
     } else if (event instanceof DCommandNotFound) {
       const newCommand = (
         DCommandNotFound
-        .createCommandNotFound()
-        .decorate(
-          target,
-          event.key,
-          event.method,
-          classType
-        )
+          .createCommandNotFound()
+          .decorate(
+            target,
+            event.key,
+            event.method,
+            classType
+          )
       );
       MetadataStorage.instance.addCommandNotFound(newCommand);
     } else {
       const newCommand = (
         DOn
-        .createOn(
-          event.event,
-          event.once
-        )
-        .decorate(
-          target,
-          event.key,
-          event.method,
-          classType
-        )
+          .createOn(
+            event.event,
+            event.once
+          )
+          .decorate(
+            target,
+            event.key,
+            event.method,
+            classType
+          )
       );
       MetadataStorage.instance.addOn(newCommand);
     }
@@ -72,12 +72,12 @@ export function Discord(prefix: Expression, params: DiscordParamsLimited);
 export function Discord(prefix: ExpressionFunction);
 export function Discord(prefix: ExpressionFunction, params: DiscordParamsLimited);
 export function Discord(prefix?: Expression | ExpressionFunction, params?: DiscordParams) {
-  const finalParams = params  || {};
+  const finalParams = params || {};
 
   return (target: Function) => {
     if (finalParams?.import) {
       let importCommands = finalParams?.import || [];
-      if (!Array.isArray(importCommands)) {
+      if (!Array.isArray(importCommands)) {
         importCommands = [importCommands];
       }
 
@@ -90,8 +90,7 @@ export function Discord(prefix?: Expression | ExpressionFunction, params?: Disco
             if (classImport.default) {
               classType = classImport.default;
             } else {
-              const key = Object.keys(classImport)[0];
-              classType = classImport[key];
+              classType = Object.values(classImport).find((p: any) => p?.prototype?.constructor != null);
             }
             importCommand(classType, target);
           });
@@ -103,12 +102,12 @@ export function Discord(prefix?: Expression | ExpressionFunction, params?: Disco
 
     const instance = (
       DDiscord
-      .createDiscord(prefix)
-      .decorate(
-        target,
-        target.constructor.name,
-        target
-      )
+        .createDiscord(prefix)
+        .decorate(
+          target,
+          target.constructor.name,
+          target
+        )
     );
 
     MetadataStorage.instance.addDiscord(instance);

--- a/src/decorators/decorators/Discord.ts
+++ b/src/decorators/decorators/Discord.ts
@@ -24,42 +24,42 @@ function importCommand(classType: Function, target: Function) {
     if (event instanceof DCommand) {
       const newCommand = (
         DCommand
-          .createCommand(
-            event.commandName
-          )
-          .decorate(
-            target,
-            event.key,
-            event.method,
-            classType
-          )
+        .createCommand(
+          event.commandName
+        )
+        .decorate(
+          target,
+          event.key,
+          event.method,
+          classType
+        )
       );
       MetadataStorage.instance.addCommand(newCommand);
     } else if (event instanceof DCommandNotFound) {
       const newCommand = (
         DCommandNotFound
-          .createCommandNotFound()
-          .decorate(
-            target,
-            event.key,
-            event.method,
-            classType
-          )
+        .createCommandNotFound()
+        .decorate(
+          target,
+          event.key,
+          event.method,
+          classType
+        )
       );
       MetadataStorage.instance.addCommandNotFound(newCommand);
     } else {
       const newCommand = (
         DOn
-          .createOn(
-            event.event,
-            event.once
-          )
-          .decorate(
-            target,
-            event.key,
-            event.method,
-            classType
-          )
+        .createOn(
+          event.event,
+          event.once
+        )
+        .decorate(
+          target,
+          event.key,
+          event.method,
+          classType
+        )
       );
       MetadataStorage.instance.addOn(newCommand);
     }
@@ -72,12 +72,12 @@ export function Discord(prefix: Expression, params: DiscordParamsLimited);
 export function Discord(prefix: ExpressionFunction);
 export function Discord(prefix: ExpressionFunction, params: DiscordParamsLimited);
 export function Discord(prefix?: Expression | ExpressionFunction, params?: DiscordParams) {
-  const finalParams = params || {};
+  const finalParams = params  || {};
 
   return (target: Function) => {
     if (finalParams?.import) {
       let importCommands = finalParams?.import || [];
-      if (!Array.isArray(importCommands)) {
+      if (!Array.isArray(importCommands)) {
         importCommands = [importCommands];
       }
 
@@ -90,6 +90,7 @@ export function Discord(prefix?: Expression | ExpressionFunction, params?: Disco
             if (classImport.default) {
               classType = classImport.default;
             } else {
+              const key = Object.keys(classImport)[0];
               classType = Object.values(classImport).find((p: any) => p?.prototype?.constructor != null);
             }
             importCommand(classType, target);
@@ -102,12 +103,12 @@ export function Discord(prefix?: Expression | ExpressionFunction, params?: Disco
 
     const instance = (
       DDiscord
-        .createDiscord(prefix)
-        .decorate(
-          target,
-          target.constructor.name,
-          target
-        )
+      .createDiscord(prefix)
+      .decorate(
+        target,
+        target.constructor.name,
+        target
+      )
     );
 
     MetadataStorage.instance.addDiscord(instance);

--- a/src/decorators/decorators/Discord.ts
+++ b/src/decorators/decorators/Discord.ts
@@ -90,7 +90,6 @@ export function Discord(prefix?: Expression | ExpressionFunction, params?: Disco
             if (classImport.default) {
               classType = classImport.default;
             } else {
-              const key = Object.keys(classImport)[0];
               classType = Object.values(classImport).find((p: any) => p?.prototype?.constructor != null);
             }
             importCommand(classType, target);


### PR DESCRIPTION
If a user creates a file containing commands that is being imported through @Discord import, the very first export of the file had to be the class containing all of the commands. If the first export was something else, in example a string, a run time error will occur and the process will exit. The error returned is "Uncaught TypeError: classType is not a constructor". 

This fix will allow users to be able to export constant values regardless of the location of the file without affecting the intended use of the class containing all of the commands.