### PR TITLE
Issue: Two different types with this name exist

### DIFF
--- a/src/decorators/classes/DChoice.ts
+++ b/src/decorators/classes/DChoice.ts
@@ -23,7 +23,7 @@ export class DChoice<Type = any> extends Decorator {
     super();
   }
 
-  static create<Type = any>(name: string, value: Type) {
+  static create<Type = any>(name: string, value: any) {
     const choice = new DChoice<Type>();
 
     choice.name = name;


### PR DESCRIPTION
Type 'Type' is not assignable to type 'Type'. Two different types with this name exist, but they are unrelated.
  'Type' could be instantiated with an arbitrary type which could be unrelated to 'Type'.