### PR TITLE
Fix: slash command options parsing

### DIFF
--- a/src/decorators/classes/DSlash.ts
+++ b/src/decorators/classes/DSlash.ts
@@ -130,23 +130,7 @@ export class DSlash extends Method {
     }));
   }
 
-  getLastNestedOption(options: Map<string, CommandInteractionOption>): CommandInteractionOption[] {
-    const arrOptions = Array.from(options?.values());
-    
-    if (!arrOptions?.[0]?.options) {
-      return arrOptions;
-    }
-
-    return this.getLastNestedOption(arrOptions?.[0].options);
-  }
-
   parseParams(interaction: CommandInteraction) {
-    const options = this.getLastNestedOption(interaction.options);
-
-    const values = this.options.map((opt, index) => {
-      return options[index]?.value;
-    });
-
-    return values;
+    return this.options.sort((a, b) => a.index - b.index).map((op) => interaction?.options?.get(op.name)?.value);
   }
 }

--- a/src/decorators/classes/DSlash.ts
+++ b/src/decorators/classes/DSlash.ts
@@ -1,11 +1,12 @@
 import {
   ApplicationCommandData,
+  ApplicationCommandOptionData,
   ApplicationCommandPermissionData,
+  Collection,
   CommandInteraction,
   CommandInteractionOption,
-  Snowflake,
 } from "discord.js";
-import { DOption, Client, SubValueType, PermissionType } from "../..";
+import { DOption, Client, SubValueType } from "../..";
 import { Method } from "./Method";
 
 export class DSlash extends Method {
@@ -13,7 +14,7 @@ export class DSlash extends Method {
   private _name: string;
   private _defaultPermission: boolean = true;
   private _options: DOption[] = [];
-  private _permissions: { id: string, type: PermissionType }[] = [];
+  private _permissions: string[] = [];
   private _guilds: string[];
   private _group: string;
   private _subgroup: string;
@@ -125,12 +126,24 @@ export class DSlash extends Method {
   getPermissions(): ApplicationCommandPermissionData[] {
     return this.permissions.map((permission) => ({
       permission: true,
-      id: permission.id as Snowflake,
-      type: permission.type,
+      id: permission as any,
+      type: 1,
     }));
   }
 
+  getLastNestedOption(options: Map<string, CommandInteractionOption>): CommandInteractionOption[] {
+    const arrOptions = Array.from(options?.values());
+    
+    if (!arrOptions?.[0]?.options) {
+      return arrOptions;
+    }
+
+    return this.getLastNestedOption(arrOptions?.[0].options);
+  }
+
   parseParams(interaction: CommandInteraction) {
-    return this.options.sort((a, b) => a.index - b.index).map((op) => interaction?.options?.get(op.name)?.value);
+    const options = this.getLastNestedOption(interaction.options);
+
+    return this.options.sort((a, b) => a.index - b.index).map((op) => options.find((o) => o.name === op.name)?.value);
   }
 }


### PR DESCRIPTION
### Issue
1. create a slash command with two optional options, example: /test option_a option_b
2. now on discord use this command as  ``/test option_b: 123`` (here we are using option_b only and leaving option_a blank)
3. when discord.ts try to execute the original command, parameter passed are ``[123, undefined]`` (which is the issue, because it was suppose to ``[undefined, 123]``)

### Fix
I have looked at the code, I think, this suggested approach is more appropriate. 

Thanks