### PR TITLE
Fix: slash command options parsing

### DIFF
--- a/src/decorators/classes/DSlash.ts
+++ b/src/decorators/classes/DSlash.ts
@@ -143,10 +143,6 @@ export class DSlash extends Method {
   parseParams(interaction: CommandInteraction) {
     const options = this.getLastNestedOption(interaction.options);
 
-    const values = this.options.map((opt, index) => {
-      return options[index]?.value;
-    });
-
-    return values;
+    return this.options.sort((a, b) => a.index - b.index).map((op) => options.find((o) => o.name === op.name)?.value);
   }
 }


### PR DESCRIPTION
### Issue
1. create a slash command with two optional options, example: /test option_a option_b
2. now on discord use this command as  ``/test option_b: 123`` (here we are using option_b only and leaving option_a blank)
3. when discord.ts try to execute the original command, parameter passed are ``[123, undefined]`` (which is the issue, because it was suppose to ``[undefined, 123]``)

### Fix
I have looked at the code, I think, this suggested approach is more appropriate. 

Thanks